### PR TITLE
Upgrade to PHP 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: docker-compose run composer
+      - name: Run unit tests
+        run: docker-compose build unit-test && docker-compose run unit-test

--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,17 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.1",
-        "lcobucci/jwt":"~3.4.5",
+        "php": "^8.0",
+        "lcobucci/jwt":"^4.0",
         "laminas/laminas-servicemanager": "^3.4",
         "laminas/laminas-modulemanager": "^2.8",
         "laminas/laminas-authentication": "^2.7",
         "laminas/laminas-http": "^2.11",
-        "laminas/laminas-console": "^2.8",
         "laminas/laminas-mvc": "^3.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/Factory/JwtServiceFactory.php
+++ b/src/Service/Factory/JwtServiceFactory.php
@@ -6,10 +6,12 @@ namespace JwtLaminasAuth\Service\Factory;
 
 use Interop\Container\ContainerInterface;
 use JwtLaminasAuth\Service\JwtService;
-use Lcobucci\JWT\Parser;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use RuntimeException;
-use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
 
 class JwtServiceFactory implements FactoryInterface
 {
@@ -38,10 +40,11 @@ class JwtServiceFactory implements FactoryInterface
             throw new RuntimeException('A verify key was not provided');
         }
 
+        $configuration = Configuration::forAsymmetricSigner($signer, InMemory::plainText($config['signKey']), InMemory::plainText($config['verifyKey']));
+        $configuration->setValidationConstraints(new SignedWith($signer, InMemory::plainText($config['verifyKey'])));
+
         return new JwtService(
-            $signer,
-            new Parser(),
-            $config['verifyKey'],
+            $configuration,
             $config['signKey']
         );
     }

--- a/test/Authentication/Storage/CookieTest.php
+++ b/test/Authentication/Storage/CookieTest.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JwtLaminasAuthTest\Authentication\Storage;
 
 use JwtLaminasAuth\Authentication\Storage\Cookie;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Laminas\Console\Request as ConsoleRequest;
 use Laminas\Http\Header\Cookie as CookieHeader;
 use Laminas\Http\Request;
 use Laminas\Http\Response;
@@ -34,7 +35,6 @@ class CookieTest extends MockeryTestCase
             [$request, 'token'],
             [$emptyRequest, null],
             [new Request(), null],
-            [new ConsoleRequest(), null]
         ];
     }
 
@@ -70,7 +70,6 @@ class CookieTest extends MockeryTestCase
             [$request, false],
             [$emptyRequest, true],
             [new Request(), true],
-            [new ConsoleRequest(), true]
         ];
     }
 

--- a/test/Authentication/Storage/HeaderTest.php
+++ b/test/Authentication/Storage/HeaderTest.php
@@ -4,7 +4,6 @@ namespace JwtLaminasAuthTest\Authentication\Storage;
 
 use JwtLaminasAuth\Authentication\Storage\Header;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Laminas\Console\Request as ConsoleRequest;
 use Laminas\Http\Request;
 use Laminas\Http\Response;
 
@@ -33,7 +32,6 @@ class HeaderTest extends MockeryTestCase
             [$request, 'token'],
             [$emptyRequest, null],
             [new Request(), null],
-            [new ConsoleRequest(), null]
         ];
     }
 
@@ -60,7 +58,6 @@ class HeaderTest extends MockeryTestCase
             [$request, false],
             [$emptyRequest, true],
             [new Request(), true],
-            [new ConsoleRequest(), true]
         ];
     }
 

--- a/unittest.Dockerfile
+++ b/unittest.Dockerfile
@@ -3,7 +3,7 @@ COPY composer.json composer.json
 COPY composer.lock composer.lock
 RUN composer install --no-interaction
 
-FROM php:7.4-fpm-alpine
+FROM php:8.0-fpm-alpine
 
 COPY ./ /app
 COPY --from=composer /app/vendor /app/vendor


### PR DESCRIPTION
- Update lcobucci/jwt to v4
  - Use `Configuration` rather than creating Builders etc. on the fly
  - Replace `getClaim()` with `claims()->get()` and check output rather than using `OutOfBoundsException`
  - Update tests to use new API
- Drop support for laminas/laminas-console
- Update PHPUnit to v9
- Run unit tests in GitHub workflow