### PR TITLE
Improve parseToken method

### DIFF
--- a/src/Service/Exception/InvalidJwtException.php
+++ b/src/Service/Exception/InvalidJwtException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace JwtLaminasAuth\Service\Exception;
+
+use InvalidArgumentException;
+
+class InvalidJwtException extends InvalidArgumentException
+{
+}

--- a/src/Service/Factory/JwtServiceFactory.php
+++ b/src/Service/Factory/JwtServiceFactory.php
@@ -9,8 +9,10 @@ use JwtLaminasAuth\Service\JwtService;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use RuntimeException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 
 class JwtServiceFactory implements FactoryInterface
@@ -41,7 +43,10 @@ class JwtServiceFactory implements FactoryInterface
         }
 
         $configuration = Configuration::forAsymmetricSigner($signer, InMemory::plainText($config['signKey']), InMemory::plainText($config['verifyKey']));
-        $configuration->setValidationConstraints(new SignedWith($signer, InMemory::plainText($config['verifyKey'])));
+        $configuration->setValidationConstraints(
+            new SignedWith($signer, InMemory::plainText($config['verifyKey'])),
+            new LooseValidAt(SystemClock::fromUTC()),
+        );
 
         return new JwtService(
             $configuration,

--- a/test/Authentication/Service/JwtServiceTest.php
+++ b/test/Authentication/Service/JwtServiceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JwtLaminasAuthTest\Authentication\Service;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use JwtLaminasAuth\Service\Exception\InvalidJwtException;
+use JwtLaminasAuth\Service\JwtService;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\DataSet;
+use Lcobucci\JWT\Token\Plain;
+use Lcobucci\JWT\Token\Signature;
+use Lcobucci\JWT\Validator;
+use Lcobucci\JWT\Validation\Constraint;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\MockInterface;
+
+class JwtServiceTest extends MockeryTestCase
+{
+    private Signer|MockInterface $mockSigner;
+    private Key|MockInterface $mockSigningKey;
+    private Key|MockInterface $mockVerificationKey;
+
+    private Configuration $config;
+    private JwtService $sut;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockSigner = m::mock(Signer::class);
+        $this->mockSigningKey = m::mock(Key::class);
+        $this->mockVerificationKey = m::mock(Key::class);
+
+        $this->config = Configuration::forAsymmetricSigner($this->mockSigner, $this->mockSigningKey, $this->mockVerificationKey);
+
+        $this->sut = new JwtService($this->config, 'my-signing-key');
+    }
+
+    public function test_createSignedToken()
+    {
+        $mockToken = new Plain(new DataSet([], ''), new DataSet([], ''), new Signature('', ''));
+
+        /** @var Builder|MockInterface */
+        $mockBuilder = m::mock(Builder::class);
+        $mockBuilder->shouldReceive('issuedAt')->withArgs(function (DateTimeImmutable $time) {
+            return $time->getTimestamp() === (new DateTimeImmutable())->getTimestamp();
+        })->andReturnSelf();
+        $mockBuilder->shouldReceive('expiresAt')->withArgs(function (DateTimeImmutable $time) {
+            return $time->getTimestamp() === (new DateTimeImmutable())->getTimestamp() + 100;
+        })->andReturnSelf();
+        $mockBuilder->shouldReceive('withClaim')->with('claim', 'value')->andReturnSelf();
+        $mockBuilder->shouldReceive('getToken')->with($this->mockSigner, $this->mockSigningKey)->andReturn($mockToken);
+
+        $this->config->setBuilderFactory(function () use ($mockBuilder) {
+            return $mockBuilder;
+        });
+
+        $token = $this->sut->createSignedToken('claim', 'value', 100);
+        $this->assertEquals($mockToken, $token);
+    }
+
+    public function test_parseToken()
+    {
+        $mockToken = new Plain(new DataSet([], ''), new DataSet([], ''), new Signature('', ''));
+
+        /** @var Parser|MockInterface */
+        $mockParser = m::mock(Parser::class);
+        $mockParser->shouldReceive('parse')->with('encoded jwt')->andReturn($mockToken);
+
+        /** @var Constraint|MockInterface */
+        $mockConstraint = m::mock(Constraint::class);
+
+        /** @var Validator|MockInterface */
+        $mockValidator = m::mock(Validator::class);
+        $mockValidator->shouldReceive('validate')->with($mockToken, $mockConstraint)->andReturn(true);
+
+        $this->config->setParser($mockParser);
+        $this->config->setValidator($mockValidator);
+        $this->config->setValidationConstraints($mockConstraint);
+
+        $this->sut->parseToken('encoded jwt');
+    }
+
+    public function test_parseToken_handles_invalid_parse()
+    {
+        /** @var Parser|MockInterface */
+        $mockParser = m::mock(Parser::class);
+        $mockParser->shouldReceive('parse')->with('encoded jwt')->andThrow(new InvalidArgumentException('Could not decode JWT'));
+
+        $this->config->setParser($mockParser);
+
+        $this->expectException(InvalidJwtException::class);
+        $this->expectExceptionMessage('Could not decode JWT');
+        $this->sut->parseToken('encoded jwt');
+    }
+
+    public function test_parseToken_handles_invalid_constraint()
+    {
+        /** @var Token|MockInterface */
+        $mockToken = m::mock(Token::class);
+
+        /** @var Parser|MockInterface */
+        $mockParser = m::mock(Parser::class);
+        $mockParser->shouldReceive('parse')->with('encoded jwt')->andReturn($mockToken);
+
+        /** @var Constraint|MockInterface */
+        $mockConstraint = m::mock(Constraint::class);
+
+        /** @var Validator|MockInterface */
+        $mockValidator = m::mock(Validator::class);
+        $mockValidator->shouldReceive('validate')->with($mockToken, $mockConstraint)->andReturn(false);
+
+        $this->config->setParser($mockParser);
+        $this->config->setValidator($mockValidator);
+        $this->config->setValidationConstraints($mockConstraint);
+
+        $this->expectException(InvalidJwtException::class);
+        $this->expectExceptionMessage('Constraints were not met');
+        $this->sut->parseToken('encoded jwt');
+    }
+}


### PR DESCRIPTION
- Stop trying to create `new Token()`: Token is an interface. Instead, throw an _intentional_ exception
- Specifically return a `Plain` because that's the only token you'll ever get back
- Validate the token's issue and expiry dates
- Add tests to JwtService