### PR TITLE
Require lcobucci/clock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "laminas/laminas-modulemanager": "^2.8",
         "laminas/laminas-authentication": "^2.7",
         "laminas/laminas-http": "^2.11",
-        "laminas/laminas-mvc": "^3.1"
+        "laminas/laminas-mvc": "^3.1",
+        "lcobucci/clock": "^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "639018560af72298e1e690171f4c5632",
+    "content-hash": "cc000b492ca88d2c5f38e68a99e7a875",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1127,6 +1127,70 @@
                 }
             ],
             "time": "2023-02-09T16:07:15+00:00"
+        },
+        {
+            "name": "lcobucci/clock",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "6f28b826ea01306b07980cb8320ab30b966cd715"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/6f28b826ea01306b07980cb8320ab30b966cd715",
+                "reference": "6f28b826ea01306b07980cb8320ab30b966cd715",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.27",
+                "lcobucci/coding-standard": "^11.0.0",
+                "phpstan/extension-installer": "^1.3.1",
+                "phpstan/phpstan": "^1.10.25",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^10.2.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
+                }
+            ],
+            "description": "Yet another clock abstraction",
+            "support": {
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2023-11-17T17:00:27+00:00"
         },
         {
             "name": "lcobucci/jwt",

--- a/unittest.Dockerfile
+++ b/unittest.Dockerfile
@@ -3,7 +3,7 @@ COPY composer.json composer.json
 COPY composer.lock composer.lock
 RUN composer install --no-interaction
 
-FROM php:8.1-fpm-alpine
+FROM php:8.2-fpm-alpine
 
 COPY ./ /app
 COPY --from=composer /app/vendor /app/vendor


### PR DESCRIPTION
We use this in `JwtServiceFactory`. It was omitted before since it was a transitive dependency through lcobucci/jwt, but that's been dropped in v5 so we now need to require it explicitly.